### PR TITLE
Add current vTPM driver

### DIFF
--- a/MdePkg/Include/Register/Amd/Svsm.h
+++ b/MdePkg/Include/Register/Amd/Svsm.h
@@ -98,4 +98,23 @@ typedef union {
   UINT64    Uint64;
 } SVSM_FUNCTION;
 
+/// SVSM Guest Protocols
+/// @{
+#define SVSM_PROTOCOL_CORE         0
+#define SVSM_PROTOCOL_ATTESTATION  1
+#define SVSM_PROTOCOL_VTPM         2
+/// @}
+
+/// SVSM Core Protocol calls
+/// @{
+#define SVSM_CORE_REMAP_CA        0
+#define SVSM_CORE_PVALIDATE       1
+#define SVSM_CORE_CREATE_VCPU     2
+#define SVSM_CORE_DELETE_VCPU     3
+#define SVSM_CORE_DEPOSIT_MEM     4
+#define SVSM_CORE_WITHDRAW_MEM    5
+#define SVSM_CORE_QUERY_PROTOCOL  6
+#define SVSM_CORE_CONFIGURE_VTOM  7
+/// @}
+
 #endif

--- a/MdePkg/Include/Register/Amd/Svsm.h
+++ b/MdePkg/Include/Register/Amd/Svsm.h
@@ -117,4 +117,10 @@ typedef union {
 #define SVSM_CORE_CONFIGURE_VTOM  7
 /// @}
 
+/// SVSM vTPM Protocol calls
+/// @{
+#define SVSM_VTPM_QUERY  0
+#define SVSM_VTPM_CMD    1
+/// @}
+
 #endif

--- a/OvmfPkg/Include/Dsc/OvmfTpmComponentsDxe.dsc.inc
+++ b/OvmfPkg/Include/Dsc/OvmfTpmComponentsDxe.dsc.inc
@@ -6,7 +6,7 @@
   SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.inf {
     <LibraryClasses>
       Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibRouter/Tpm2DeviceLibRouterDxe.inf
-      NULL|SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpm.inf
+      NULL|SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpmSvsm.inf
       HashLib|SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.inf
       NULL|SecurityPkg/Library/HashInstanceLibSha1/HashInstanceLibSha1.inf
       NULL|SecurityPkg/Library/HashInstanceLibSha256/HashInstanceLibSha256.inf

--- a/OvmfPkg/Include/Dsc/OvmfTpmLibs.dsc.inc
+++ b/OvmfPkg/Include/Dsc/OvmfTpmLibs.dsc.inc
@@ -30,7 +30,7 @@
 !if $(TPM1_ENABLE) == TRUE
   Tpm12DeviceLib|SecurityPkg/Library/Tpm12DeviceLibDTpm/Tpm12DeviceLibDTpm.inf
 !endif
-  Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.inf
+  Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpmSvsm.inf
 !endif
 
 [LibraryClasses.common.DXE_DRIVER]

--- a/OvmfPkg/Library/AmdSvsmLib/AmdSvsmLib.c
+++ b/OvmfPkg/Library/AmdSvsmLib/AmdSvsmLib.c
@@ -213,8 +213,8 @@ SvsmPvalidate (
   Caa = (SVSM_CAA *)AmdSvsmSnpGetCaa ();
   ZeroMem (Caa->SvsmBuffer, sizeof (Caa->SvsmBuffer));
 
-  Function.Id.Protocol = 0;
-  Function.Id.CallId   = 1;
+  Function.Id.Protocol = SVSM_PROTOCOL_CORE;
+  Function.Id.CallId   = SVSM_CORE_PVALIDATE;
 
   Request    = (SVSM_PVALIDATE_REQUEST *)Caa->SvsmBuffer;
   EntryLimit = ((sizeof (Caa->SvsmBuffer) - sizeof (*Request)) /
@@ -407,17 +407,17 @@ SvsmVmsaRmpAdjust (
 
   SvsmCallData.Caa = (SVSM_CAA *)AmdSvsmSnpGetCaa ();
 
-  Function.Id.Protocol = 0;
+  Function.Id.Protocol = SVSM_PROTOCOL_CORE;
 
   if (SetVmsa) {
-    Function.Id.CallId = 2;
+    Function.Id.CallId = SVSM_CORE_CREATE_VCPU;
 
     SvsmCallData.RaxIn = Function.Uint64;
     SvsmCallData.RcxIn = (UINT64)(UINTN)Vmsa;
     SvsmCallData.RdxIn = (UINT64)(UINTN)Vmsa + SIZE_4KB;
     SvsmCallData.R8In  = ApicId;
   } else {
-    Function.Id.CallId = 3;
+    Function.Id.CallId = SVSM_CORE_DELETE_VCPU;
 
     SvsmCallData.RaxIn = Function.Uint64;
     SvsmCallData.RcxIn = (UINT64)(UINTN)Vmsa;

--- a/OvmfPkg/Library/AmdSvsmLib/AmdSvsmLib.c
+++ b/OvmfPkg/Library/AmdSvsmLib/AmdSvsmLib.c
@@ -498,3 +498,96 @@ AmdSvsmSnpVmsaRmpAdjust (
   return AmdSvsmIsSvsmPresent () ? SvsmVmsaRmpAdjust (Vmsa, ApicId, SetVmsa)
                                 : BaseVmsaRmpAdjust (Vmsa, SetVmsa);
 }
+
+/**
+  Perform a SVSM_VTPM_QUERY operation
+
+  Query the support provided by the SVSM vTPM.
+
+  @param[out] PlatformCommands    It will contain a bitmap indicating the
+                                  supported vTPM platform commands.
+  @param[out] Features            It will contain a bitmap indicating the
+                                  supported vTPM features.
+
+  @retval TRUE                    The query was processed.
+  @retval FALSE                   The query was not processed.
+
+**/
+BOOLEAN
+EFIAPI
+AmdSvsmVtpmQuery (
+  OUT UINT64  *PlatformCommands,
+  OUT UINT64  *Features
+  )
+{
+  SVSM_CALL_DATA  SvsmCallData;
+  SVSM_FUNCTION   Function;
+
+  if (!PlatformCommands && !Features) {
+    return FALSE;
+  }
+
+  if (!AmdSvsmIsSvsmPresent ()) {
+    return FALSE;
+  }
+
+  Function.Id.Protocol = SVSM_PROTOCOL_VTPM;
+  Function.Id.CallId   = SVSM_VTPM_QUERY;
+
+  SvsmCallData.Caa   = (SVSM_CAA *)AmdSvsmSnpGetCaa ();
+  SvsmCallData.RaxIn = Function.Uint64;
+
+  if (SvsmMsrProtocol (&SvsmCallData)) {
+    return FALSE;
+  }
+
+  if (PlatformCommands) {
+    *PlatformCommands = SvsmCallData.RcxOut;
+  }
+
+  if (Features) {
+    *Features = SvsmCallData.RdxOut;
+  }
+
+  return TRUE;
+}
+
+/**
+  Perform a SVSM_VTPM_CMD operation
+
+  Send the specified vTPM platform command to the SVSM vTPM.
+
+  @param[in, out] Buffer  It should contain the vTPM platform command
+                          request. The respective response will be returned
+                          in the same Buffer, but not all commands specify a
+                          response.
+
+  @retval TRUE            The command was processed.
+  @retval FALSE           The command was not processed.
+
+**/
+BOOLEAN
+EFIAPI
+AmdSvsmVtpmCmd (
+  IN OUT UINT8  *Buffer
+  )
+{
+  SVSM_CALL_DATA  SvsmCallData;
+  SVSM_FUNCTION   Function;
+  UINTN           Ret;
+
+  if (!AmdSvsmIsSvsmPresent ()) {
+    return FALSE;
+  }
+
+  Function.Id.Protocol = SVSM_PROTOCOL_VTPM;
+  Function.Id.CallId   = SVSM_VTPM_CMD;
+
+  SvsmCallData.Caa   = (SVSM_CAA *)AmdSvsmSnpGetCaa ();
+  SvsmCallData.RaxIn = Function.Uint64;
+  SvsmCallData.RcxIn = (UINT64)(UINTN)Buffer;
+
+  Ret = SvsmMsrProtocol (&SvsmCallData);
+
+  return (Ret == 0) ? TRUE : FALSE;
+}

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.c
@@ -13,41 +13,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/Tpm2DeviceLib.h>
 #include <Library/PcdLib.h>
 
+#include "Tpm2Ptp.h"
 #include "Tpm2DeviceLibDTpm.h"
-
-/**
-  This service enables the sending of commands to the TPM2.
-
-  @param[in]      InputParameterBlockSize  Size of the TPM2 input parameter block.
-  @param[in]      InputParameterBlock      Pointer to the TPM2 input parameter block.
-  @param[in,out]  OutputParameterBlockSize Size of the TPM2 output parameter block.
-  @param[in]      OutputParameterBlock     Pointer to the TPM2 output parameter block.
-
-  @retval EFI_SUCCESS            The command byte stream was successfully sent to the device and a response was successfully received.
-  @retval EFI_DEVICE_ERROR       The command was not successfully sent to the device or a response was not successfully received from the device.
-  @retval EFI_BUFFER_TOO_SMALL   The output parameter block is too small.
-**/
-EFI_STATUS
-EFIAPI
-DTpm2SubmitCommand (
-  IN UINT32      InputParameterBlockSize,
-  IN UINT8       *InputParameterBlock,
-  IN OUT UINT32  *OutputParameterBlockSize,
-  IN UINT8       *OutputParameterBlock
-  );
-
-/**
-  This service requests use TPM2.
-
-  @retval EFI_SUCCESS      Get the control of TPM2 chip.
-  @retval EFI_NOT_FOUND    TPM2 not found.
-  @retval EFI_DEVICE_ERROR Unexpected device behavior.
-**/
-EFI_STATUS
-EFIAPI
-DTpm2RequestUseTpm (
-  VOID
-  );
 
 /**
   This service enables the sending of commands to the TPM2.

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpmSvsm.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpmSvsm.c
@@ -1,0 +1,98 @@
+/** @file
+  This library is a TPM2 DTPM instance, supporting SVSM based vTPMs and regular
+  TPM2s at the same time.
+  Choosing this library means platform uses and only uses DTPM device as TPM2 engine.
+
+Copyright (c) 2013 - 2018, Intel Corporation. All rights reserved. <BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/Tpm2DeviceLib.h>
+
+#include "Tpm2DeviceLibDTpm.h"
+#include "Tpm2PtpSvsmShim.h"
+
+/**
+  This service enables the sending of commands to the TPM2.
+
+  @param[in]      InputParameterBlockSize  Size of the TPM2 input parameter block.
+  @param[in]      InputParameterBlock      Pointer to the TPM2 input parameter block.
+  @param[in,out]  OutputParameterBlockSize Size of the TPM2 output parameter block.
+  @param[in]      OutputParameterBlock     Pointer to the TPM2 output parameter block.
+
+  @retval EFI_SUCCESS            The command byte stream was successfully sent to the device and a response was successfully received.
+  @retval EFI_DEVICE_ERROR       The command was not successfully sent to the device or a response was not successfully received from the device.
+  @retval EFI_BUFFER_TOO_SMALL   The output parameter block is too small.
+**/
+EFI_STATUS
+EFIAPI
+Tpm2SubmitCommand (
+  IN UINT32      InputParameterBlockSize,
+  IN UINT8       *InputParameterBlock,
+  IN OUT UINT32  *OutputParameterBlockSize,
+  IN UINT8       *OutputParameterBlock
+  )
+{
+  return SvsmDTpm2SubmitCommand (
+           InputParameterBlockSize,
+           InputParameterBlock,
+           OutputParameterBlockSize,
+           OutputParameterBlock
+           );
+}
+
+/**
+  This service requests use TPM2.
+
+  @retval EFI_SUCCESS      Get the control of TPM2 chip.
+  @retval EFI_NOT_FOUND    TPM2 not found.
+  @retval EFI_DEVICE_ERROR Unexpected device behavior.
+**/
+EFI_STATUS
+EFIAPI
+Tpm2RequestUseTpm (
+  VOID
+  )
+{
+  return SvsmDTpm2RequestUseTpm ();
+}
+
+/**
+  This service register TPM2 device.
+
+  @param Tpm2Device  TPM2 device
+
+  @retval EFI_SUCCESS          This TPM2 device is registered successfully.
+  @retval EFI_UNSUPPORTED      System does not support register this TPM2 device.
+  @retval EFI_ALREADY_STARTED  System already register this TPM2 device.
+**/
+EFI_STATUS
+EFIAPI
+Tpm2RegisterTpm2DeviceLib (
+  IN TPM2_DEVICE_INTERFACE  *Tpm2Device
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  The function caches current active TPM interface type.
+
+  @retval EFI_SUCCESS   DTPM2.0 instance is registered, or system does not support register DTPM2.0 instance
+**/
+EFI_STATUS
+EFIAPI
+Tpm2DeviceLibConstructorSvsm (
+  VOID
+  )
+{
+  if (TryUseSvsmVTpm ()) {
+    DEBUG ((DEBUG_INFO, "Tpm2DeviceLib: Found SVSM vTPM\n"));
+    return EFI_SUCCESS;
+  } else {
+    return InternalTpm2DeviceLibDTpmCommonConstructor ();
+  }
+}

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpmSvsm.inf
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpmSvsm.inf
@@ -1,0 +1,64 @@
+## @file
+#  Provides SVSM based vTPM and regular TPM 2.0 TIS/PTP functions for DTPM
+#
+#  Spec Compliance Info:
+#    "TCG PC Client Platform TPM Profile(PTP) Specification Family 2.0 Level 00 Revision 00.43"
+#    "TCG PC Client Specific TPM Interface Specification(TIS) Version 1.3"
+#
+#  This library implements TIS (TPM Interface Specification) and
+#  PTP (Platform TPM Profile) functions which is
+#  used for every TPM 2.0 command. Choosing this library means platform uses and
+#  only uses TPM 2.0 DTPM device.
+#
+#  This version of the library additionally supports SVSM based vTPMs for confidential
+#  virtual machines under AMD-SEV SNP.
+#
+# Copyright (c) 2013 - 2018, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) Microsoft Corporation.
+# Copyright (c) 2024 Red Hat
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = Tpm2DeviceLibDTpmSvsm
+  MODULE_UNI_FILE                = Tpm2DeviceLibDTpm.uni
+  FILE_GUID                      = EE79D4E4-8538-4FE6-A7EF-4095CB6B38E7
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = Tpm2DeviceLib|PEIM DXE_DRIVER DXE_RUNTIME_DRIVER DXE_SMM_DRIVER UEFI_APPLICATION UEFI_DRIVER
+  CONSTRUCTOR                    = Tpm2DeviceLibConstructorSvsm
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = X64
+#
+
+[Sources]
+  Tpm2Tis.c
+  Tpm2Svsm.c
+  Tpm2PtpSvsmShim.c
+  Tpm2Ptp.c
+  Tpm2DeviceLibDTpmSvsm.c
+  Tpm2DeviceLibDTpmBase.c
+  Tpm2DeviceLibDTpm.h
+
+[Packages]
+  MdePkg/MdePkg.dec
+  SecurityPkg/SecurityPkg.dec
+  UefiCpuPkg/UefiCpuPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  IoLib
+  TimerLib
+  DebugLib
+  PcdLib
+  AmdSvsmLib
+
+[Pcd]
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress            ## CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdActiveTpmInterfaceType    ## PRODUCES
+  gEfiSecurityPkgTokenSpaceGuid.PcdCRBIdleByPass             ## PRODUCES

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpm.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpm.c
@@ -16,51 +16,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <Guid/TpmInstance.h>
 
+#include "Tpm2Ptp.h"
 #include "Tpm2DeviceLibDTpm.h"
-
-/**
-  Dump PTP register information.
-
-  @param[in] Register                Pointer to PTP register.
-**/
-VOID
-DumpPtpInfo (
-  IN VOID  *Register
-  );
-
-/**
-  This service enables the sending of commands to the TPM2.
-
-  @param[in]      InputParameterBlockSize  Size of the TPM2 input parameter block.
-  @param[in]      InputParameterBlock      Pointer to the TPM2 input parameter block.
-  @param[in,out]  OutputParameterBlockSize Size of the TPM2 output parameter block.
-  @param[in]      OutputParameterBlock     Pointer to the TPM2 output parameter block.
-
-  @retval EFI_SUCCESS            The command byte stream was successfully sent to the device and a response was successfully received.
-  @retval EFI_DEVICE_ERROR       The command was not successfully sent to the device or a response was not successfully received from the device.
-  @retval EFI_BUFFER_TOO_SMALL   The output parameter block is too small.
-**/
-EFI_STATUS
-EFIAPI
-DTpm2SubmitCommand (
-  IN UINT32      InputParameterBlockSize,
-  IN UINT8       *InputParameterBlock,
-  IN OUT UINT32  *OutputParameterBlockSize,
-  IN UINT8       *OutputParameterBlock
-  );
-
-/**
-  This service requests use TPM2.
-
-  @retval EFI_SUCCESS      Get the control of TPM2 chip.
-  @retval EFI_NOT_FOUND    TPM2 not found.
-  @retval EFI_DEVICE_ERROR Unexpected device behavior.
-**/
-EFI_STATUS
-EFIAPI
-DTpm2RequestUseTpm (
-  VOID
-  );
 
 TPM2_DEVICE_INTERFACE  mDTpm2InternalTpm2Device = {
   TPM_DEVICE_INTERFACE_TPM20_DTPM,

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpmSvsm.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpmSvsm.c
@@ -1,0 +1,61 @@
+/** @file
+  This library is a TPM2 DTPM instance, supporting SVSM based vTPMs and regular
+  TPM2s at the same time.
+
+  It can be registered to Tpm2 Device router, to be active TPM2 engine,
+  based on platform setting.
+
+Copyright (c) 2024 Red Hat
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/Tpm2DeviceLib.h>
+#include <Library/PcdLib.h>
+
+#include <Guid/TpmInstance.h>
+
+#include "Tpm2Ptp.h"
+#include "Tpm2DeviceLibDTpm.h"
+#include "Tpm2PtpSvsmShim.h"
+
+TPM2_DEVICE_INTERFACE  mDTpm2InternalTpm2Device = {
+  TPM_DEVICE_INTERFACE_TPM20_DTPM,
+  SvsmDTpm2SubmitCommand,
+  SvsmDTpm2RequestUseTpm,
+};
+
+/**
+  The function register DTPM2.0 instance and caches current active TPM interface type.
+
+  @retval EFI_SUCCESS   DTPM2.0 instance is registered, or system does not support register DTPM2.0 instance
+**/
+EFI_STATUS
+EFIAPI
+Tpm2InstanceLibDTpmConstructorSvsm (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = Tpm2RegisterTpm2DeviceLib (&mDTpm2InternalTpm2Device);
+  if ((Status == EFI_SUCCESS) || (Status == EFI_UNSUPPORTED)) {
+    //
+    // Unsupported means platform policy does not need this instance enabled.
+    //
+    if (Status == EFI_SUCCESS) {
+      if (TryUseSvsmVTpm ()) {
+        DEBUG ((DEBUG_INFO, "Tpm2InstanceLib: Found SVSM vTPM\n"));
+      } else {
+        Status = InternalTpm2DeviceLibDTpmCommonConstructor ();
+        DumpPtpInfo ((VOID *)(UINTN)PcdGet64 (PcdTpmBaseAddress));
+      }
+    }
+
+    return EFI_SUCCESS;
+  }
+
+  return Status;
+}

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpmSvsm.inf
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpmSvsm.inf
@@ -1,0 +1,58 @@
+## @file
+#  Provides a DTPM instance for SVSM based vTPMs and TPM 2.0 TIS/PTP.
+#
+#  This library can be registered to Tpm 2.0 device router, to be active TPM 2.0
+#  engine, based on platform setting. It supports both TIS (TPM Interface Specification)
+#  and PTP (Platform TPM Profile) functions.
+#
+#  This version of the library additionally supports SVSM based vTPMs for confidential
+#  virtual machines under AMD-SEV SNP.
+#
+# Copyright (c) 2024 Red Hat
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = Tpm2InstanceLibDTpmSvsm
+  MODULE_UNI_FILE                = Tpm2InstanceLibDTpm.uni
+  FILE_GUID                      = C7777207-A8DF-47E4-AA3C-E8BF74E7F233
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = NULL
+  CONSTRUCTOR                    = Tpm2InstanceLibDTpmConstructorSvsm
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = X64
+#
+
+[Sources]
+  Tpm2Tis.c
+  Tpm2Svsm.c
+  Tpm2Ptp.c
+  Tpm2PtpSvsmShim.c
+  Tpm2InstanceLibDTpmSvsm.c
+  Tpm2DeviceLibDTpmBase.c
+  Tpm2DeviceLibDTpm.h
+
+[Packages]
+  MdePkg/MdePkg.dec
+  SecurityPkg/SecurityPkg.dec
+  UefiCpuPkg/UefiCpuPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  IoLib
+  TimerLib
+  DebugLib
+  PcdLib
+  AmdSvsmLib
+
+[Pcd]
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress          ## CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdActiveTpmInterfaceType  ## PRODUCES
+  gEfiSecurityPkgTokenSpaceGuid.PcdCRBIdleByPass           ## PRODUCES

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.c
@@ -22,6 +22,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include "Tpm2DeviceLibDTpm.h"
 
+#include "Tpm2Ptp.h"
+
 //
 // Execution of the command may take from several seconds to minutes for certain
 // commands, such as key generation.

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.h
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.h
@@ -1,0 +1,53 @@
+/** @file
+  PTP (Platform TPM Profile) CRB (Command Response Buffer) interface used by dTPM2.0 library.
+
+Copyright (c) 2024 Red Hat
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+
+/**
+  Dump PTP register information.
+
+  @param[in] Register                Pointer to PTP register.
+**/
+VOID
+DumpPtpInfo (
+  IN VOID  *Register
+  );
+
+/**
+  This service enables the sending of commands to the TPM2.
+
+  @param[in]      InputParameterBlockSize  Size of the TPM2 input parameter block.
+  @param[in]      InputParameterBlock      Pointer to the TPM2 input parameter block.
+  @param[in,out]  OutputParameterBlockSize Size of the TPM2 output parameter block.
+  @param[in]      OutputParameterBlock     Pointer to the TPM2 output parameter block.
+
+  @retval EFI_SUCCESS            The command byte stream was successfully sent to the device and a response was successfully received.
+  @retval EFI_DEVICE_ERROR       The command was not successfully sent to the device or a response was not successfully received from the device.
+  @retval EFI_BUFFER_TOO_SMALL   The output parameter block is too small.
+**/
+EFI_STATUS
+EFIAPI
+DTpm2SubmitCommand (
+  IN UINT32      InputParameterBlockSize,
+  IN UINT8       *InputParameterBlock,
+  IN OUT UINT32  *OutputParameterBlockSize,
+  IN UINT8       *OutputParameterBlock
+  );
+
+/**
+  This service requests use TPM2.
+
+  @retval EFI_SUCCESS      Get the control of TPM2 chip.
+  @retval EFI_NOT_FOUND    TPM2 not found.
+  @retval EFI_DEVICE_ERROR Unexpected device behavior.
+**/
+EFI_STATUS
+EFIAPI
+DTpm2RequestUseTpm (
+  VOID
+  );

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2PtpSvsmShim.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2PtpSvsmShim.c
@@ -1,0 +1,102 @@
+/** @file
+  PTP (Platform TPM Profile) CRB (Command Response Buffer) interface shim that switches between
+  SVSM vTPM Ptp and regular Ptp implementations.
+
+  Use TryUseSvsmVTpm () do check for SVSM vTPM presnece and initialzie the shim.
+
+Copyright (c) 2024 Red Hat
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+#include <Library/Tpm2DeviceLib.h>
+#include "Tpm2Ptp.h"
+#include "Tpm2Svsm.h"
+
+static BOOLEAN  mUseSvsmVTpm = FALSE;
+
+/**
+ Test if SVSM vTPM is present and initialize the Ptp-Svsm-Shim.
+
+ If an SVSM based vTPM is found, use it from now on.
+ If none is found, call the regular Ptp TPM implementetion instead.
+
+ This function is meant to be called from the DTpm library constructor.
+ If it has not been called, the regular Ptp implementation is used.
+
+ @retval TRUE   SVSM vTPM is present.
+ @retval FALSE  SVSM vTPM was not discovered.
+ */
+BOOLEAN
+EFIAPI
+TryUseSvsmVTpm (
+  )
+{
+  mUseSvsmVTpm = Tpm2SvsmQueryTpmSendCmd ();
+  return mUseSvsmVTpm;
+}
+
+/**
+  This service enables the sending of commands to the selected TPM2.
+
+  Commands are send to either the SVSM vTPM or the regular Ptp based TPM, depending
+  on what was discovered by TryUseSvsmVTpm ().
+
+  @param[in]      InputParameterBlockSize  Size of the TPM2 input parameter block.
+  @param[in]      InputParameterBlock      Pointer to the TPM2 input parameter block.
+  @param[in,out]  OutputParameterBlockSize Size of the TPM2 output parameter block.
+  @param[in]      OutputParameterBlock     Pointer to the TPM2 output parameter block.
+
+  @retval EFI_SUCCESS            The command byte stream was successfully sent to the device and a response was successfully received.
+  @retval EFI_DEVICE_ERROR       The command was not successfully sent to the device or a response was not successfully received from the device.
+  @retval EFI_BUFFER_TOO_SMALL   The output parameter block is too small.
+**/
+EFI_STATUS
+EFIAPI
+SvsmDTpm2SubmitCommand (
+  IN UINT32      InputParameterBlockSize,
+  IN UINT8       *InputParameterBlock,
+  IN OUT UINT32  *OutputParameterBlockSize,
+  IN UINT8       *OutputParameterBlock
+  )
+{
+  if (mUseSvsmVTpm) {
+    return Tpm2SvsmTpmSendCommand (
+             InputParameterBlock,
+             InputParameterBlockSize,
+             OutputParameterBlock,
+             OutputParameterBlockSize
+             );
+  } else {
+    return DTpm2SubmitCommand (
+             InputParameterBlockSize,
+             InputParameterBlock,
+             OutputParameterBlockSize,
+             OutputParameterBlock
+             );
+  }
+}
+
+/**
+  This service requests use TPM2.
+
+  Depending on what was discovered by TryUseSvsmVTpm (), this function either
+  returns EFI_SUCCESS, for SVSM vTPM, or calls the regular Ptp implementation.
+
+  @retval EFI_SUCCESS      Get the control of TPM2 chip.
+  @retval EFI_NOT_FOUND    TPM2 not found.
+  @retval EFI_DEVICE_ERROR Unexpected device behavior.
+**/
+EFI_STATUS
+EFIAPI
+SvsmDTpm2RequestUseTpm (
+  VOID
+  )
+{
+  if (mUseSvsmVTpm) {
+    return EFI_SUCCESS;
+  } else {
+    return DTpm2RequestUseTpm ();
+  }
+}

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2PtpSvsmShim.h
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2PtpSvsmShim.h
@@ -1,0 +1,30 @@
+/** @file
+  PTP (Platform TPM Profile) CRB (Command Response Buffer) interface shim that switches between
+  SVSM vTPM Ptp and regular Ptp implementations.
+
+  Use TryUseSvsmVTpm () do check for SVSM vTPM presnece and initialzie the shim.
+
+Copyright (c) 2024 Red Hat
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+BOOLEAN
+EFIAPI
+TryUseSvsmVTpm (
+  );
+
+EFI_STATUS
+EFIAPI
+SvsmDTpm2SubmitCommand (
+  IN UINT32      InputParameterBlockSize,
+  IN UINT8       *InputParameterBlock,
+  IN OUT UINT32  *OutputParameterBlockSize,
+  IN UINT8       *OutputParameterBlock
+  );
+
+EFI_STATUS
+EFIAPI
+SvsmDTpm2RequestUseTpm (
+  VOID
+  );

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Svsm.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Svsm.c
@@ -1,0 +1,126 @@
+/** @file
+  SVSM TPM communication
+
+Copyright (C) 2024 James.Bottomley@HansenPartnership.com
+Copyright (C) 2024 IBM Corporation
+
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/AmdSvsmLib.h>
+
+#include "Tpm2Svsm.h"
+
+/**
+  Platform commands (MSSIM commands) can be sent through the
+  SVSM_VTPM_CMD operation. Each command can have its own
+  request and response structures.
+**/
+#define TPM_SEND_COMMAND  8
+
+/* Max req/resp buffer size */
+#define TPM_PLATFORM_MAX_BUFFER  4096
+
+STATIC UINT8  Tpm2SvsmBuffer[TPM_PLATFORM_MAX_BUFFER];
+
+#pragma pack(1)
+typedef struct _TPM2_SEND_CMD_REQ {
+  UINT32    Cmd;
+  UINT8     Locality;
+  UINT32    BufSize;
+  UINT8     Buf[];
+} TPM2_SEND_CMD_REQ;
+
+typedef struct _TPM2_SEND_CMD_RESP {
+  UINT32    Size;
+  UINT8     Buf[];
+} TPM2_SEND_CMD_RESP;
+#pragma pack()
+
+/**
+  Probe the SVSM vTPM for TPM_SEND_COMMAND support. The
+  TPM_SEND_COMMAND platform command can be used to execute a
+  TPM command and get the result.
+
+  @retval TRUE    TPM_SEND_COMMAND is supported.
+  @retval FALSE   TPM_SEND_COMMAND is not supported.
+
+**/
+BOOLEAN
+Tpm2SvsmQueryTpmSendCmd (
+  VOID
+  )
+{
+  UINT64  PlatformCmdBitmap;
+  UINT64  TpmSendMask;
+
+  PlatformCmdBitmap = 0;
+  TpmSendMask       = 1 << TPM_SEND_COMMAND;
+
+  if (!AmdSvsmVtpmQuery (&PlatformCmdBitmap, NULL)) {
+    return FALSE;
+  }
+
+  return ((PlatformCmdBitmap & TpmSendMask) == TpmSendMask);
+}
+
+/**
+  Send a TPM command to the SVSM vTPM and return the TPM response.
+
+  @param[in]      BufferIn      It should contain the marshaled
+                                TPM command.
+  @param[in]      SizeIn        Size of the TPM command.
+  @param[out]     BufferOut     It will contain the marshaled
+                                TPM response.
+  @param[in, out] SizeOut       Size of the BufferOut; it will also
+                                be used to return the size of the
+                                TPM response
+
+  @retval EFI_SUCCESS           Operation completed successfully.
+  @retval EFI_INVALID_PARAMETER Buffer not provided.
+  @retval EFI_BUFFER_TOO_SMALL  Response data buffer is too small.
+  @retval EFI_DEVICE_ERROR      Unexpected device behavior.
+  @retval EFI_UNSUPPORTED       Unsupported TPM version
+
+**/
+EFI_STATUS
+Tpm2SvsmTpmSendCommand (
+  IN     UINT8   *BufferIn,
+  IN     UINT32  SizeIn,
+  OUT UINT8      *BufferOut,
+  IN OUT UINT32  *SizeOut
+  )
+{
+  TPM2_SEND_CMD_REQ   *req  = (TPM2_SEND_CMD_REQ *)Tpm2SvsmBuffer;
+  TPM2_SEND_CMD_RESP  *resp = (TPM2_SEND_CMD_RESP *)Tpm2SvsmBuffer;
+
+  if ((SizeIn == 0) || !BufferIn || !SizeOut || !BufferOut) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (SizeIn > sizeof (Tpm2SvsmBuffer) - sizeof (*req)) {
+    return EFI_BUFFER_TOO_SMALL;
+  }
+
+  req->Cmd      = TPM_SEND_COMMAND;
+  req->Locality = 0;
+  req->BufSize  = SizeIn;
+  CopyMem (req->Buf, BufferIn, SizeIn);
+
+  if (!AmdSvsmVtpmCmd (Tpm2SvsmBuffer)) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  if (resp->Size > *SizeOut) {
+    return EFI_BUFFER_TOO_SMALL;
+  }
+
+  CopyMem (BufferOut, resp->Buf, resp->Size);
+  *SizeOut = resp->Size;
+
+  return EFI_SUCCESS;
+}

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Svsm.h
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Svsm.h
@@ -1,0 +1,25 @@
+/** @file
+  SVSM TPM communication
+
+Copyright (C) 2024 James.Bottomley@HansenPartnership.com
+Copyright (C) 2024 IBM Corporation
+Copyright (C) 2024 Red Hat
+
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+
+BOOLEAN
+Tpm2SvsmQueryTpmSendCmd (
+  VOID
+  );
+
+EFI_STATUS
+Tpm2SvsmTpmSendCommand (
+  IN     UINT8   *BufferIn,
+  IN     UINT32  SizeIn,
+  OUT UINT8      *BufferOut,
+  IN OUT UINT32  *SizeOut
+  );

--- a/UefiCpuPkg/Include/Library/AmdSvsmLib.h
+++ b/UefiCpuPkg/Include/Library/AmdSvsmLib.h
@@ -98,4 +98,45 @@ AmdSvsmSnpVmsaRmpAdjust (
   IN BOOLEAN           SetVmsa
   );
 
+/**
+  Perform a SVSM_VTPM_QUERY operation
+
+  Query the support provided by the SVSM vTPM.
+
+  @param[out] PlatformCommands    It will contain a bitmap indicating the
+                                  supported vTPM platform commands.
+  @param[out] Features            It will contain a bitmap indicating the
+                                  supported vTPM features.
+
+  @retval TRUE                    The query was processed.
+  @retval FALSE                   The query was not processed.
+
+**/
+BOOLEAN
+EFIAPI
+AmdSvsmVtpmQuery (
+  OUT UINT64  *PlatformCommands,
+  OUT UINT64  *Features
+  );
+
+/**
+  Perform a SVSM_VTPM_CMD operation
+
+  Send the specified vTPM platform command to the SVSM vTPM.
+
+  @param[in, out] Buffer  It should contain the vTPM platform command
+                          request. The respective response will be returned
+                          in the same Buffer, but not all commands specify a
+                          response.
+
+  @retval TRUE            The command was processed.
+  @retval FALSE           The command was not processed.
+
+**/
+BOOLEAN
+EFIAPI
+AmdSvsmVtpmCmd (
+  IN OUT UINT8  *Buffer
+  );
+
 #endif

--- a/UefiCpuPkg/Library/AmdSvsmLibNull/AmdSvsmLibNull.c
+++ b/UefiCpuPkg/Library/AmdSvsmLibNull/AmdSvsmLibNull.c
@@ -106,3 +106,50 @@ AmdSvsmSnpVmsaRmpAdjust (
 {
   return EFI_UNSUPPORTED;
 }
+
+/**
+  Perform a SVSM_VTPM_QUERY operation
+
+  Query the support provided by the SVSM vTPM.
+
+  @param[out] PlatformCommands    It will contain a bitmap indicating the
+                                  supported vTPM platform commands.
+  @param[out] Features            It will contain a bitmap indicating the
+                                  supported vTPM features.
+
+  @retval TRUE                    The query was processed.
+  @retval FALSE                   The query was not processed.
+
+**/
+BOOLEAN
+EFIAPI
+AmdSvsmVtpmQuery (
+  OUT UINT64  *PlatformCommands,
+  OUT UINT64  *Features
+  )
+{
+  return FALSE;
+}
+
+/**
+  Perform a SVSM_VTPM_CMD operation
+
+  Send the specified vTPM platform command to the SVSM vTPM.
+
+  @param[in, out] Buffer  It should contain the vTPM platform command
+                          request. The respective response will be returned
+                          in the same Buffer, but not all commands specify a
+                          response.
+
+  @retval TRUE            The command was processed.
+  @retval FALSE           The command was not processed.
+
+**/
+BOOLEAN
+EFIAPI
+AmdSvsmVtpmCmd (
+  IN OUT UINT8  *Buffer
+  )
+{
+  return FALSE;
+}


### PR DESCRIPTION
Pull in the current state of the upstream PR for the vTPM support in EDK2.

This is still WIP since there are open comments, but it should work fine with the regular OVMF build as described in the Coconut documentation.

- https://github.com/tianocore/edk2/pull/6527