### PR TITLE
SEV-SNP does not support MTRRs

### DIFF
--- a/OvmfPkg/PlatformPei/Platform.c
+++ b/OvmfPkg/PlatformPei/Platform.c
@@ -358,6 +358,8 @@ InitializePlatform (
 
   PlatformQemuUc32BaseInitialization (PlatformInfoHob);
 
+  AmdSevInitializePcds ();
+
   InitializeRamRegions (PlatformInfoHob);
 
   if (PlatformInfoHob->BootMode != BOOT_ON_S3_RESUME) {

--- a/OvmfPkg/PlatformPei/Platform.h
+++ b/OvmfPkg/PlatformPei/Platform.h
@@ -84,6 +84,11 @@ RelocateSmBase (
   );
 
 VOID
+AmdSevInitializePcds (
+  VOID
+  );
+
+VOID
 AmdSevInitialize (
   IN EFI_HOB_PLATFORM_INFO  *PlatformInfoHob
   );

--- a/UefiCpuPkg/Library/MtrrLib/MtrrLib.c
+++ b/UefiCpuPkg/Library/MtrrLib/MtrrLib.c
@@ -19,6 +19,8 @@
 #include <Library/CpuLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
+#include <Library/PcdLib.h>
+#include <ConfidentialComputingGuestAttr.h>
 
 #define OR_SEED              0x0101010101010101ull
 #define CLEAR_SEED           0xFFFFFFFFFFFFFFFFull
@@ -142,6 +144,42 @@ MtrrDebugPrintAllMtrrsWorker (
   );
 
 /**
+Check if AMD SEV-SNP is active.
+
+@retval TRUE   AMD SEV-SNP is active.
+@retval FALSE  AMD SEV-SNP is not active.
+
+**/
+STATIC
+BOOLEAN
+EFIAPI
+SnpIsEnabled (
+  VOID
+  )
+{
+  STATIC BOOLEAN  mCurrentAttrRead = FALSE;
+  STATIC UINT64   mCurrentAttr     = 0;
+
+  if (!mCurrentAttrRead) {
+    mCurrentAttr     = PcdGet64 (PcdConfidentialComputingGuestAttr);
+    mCurrentAttrRead = TRUE;
+  }
+
+  //
+  // If attr is for the AMD group then do AMD SEV-SNP specific check.
+  //
+  if (((RShiftU64 (mCurrentAttr, 8)) & 0xff) == 1) {
+    UINT64  CurrentLevel = mCurrentAttr & CCAttrTypeMask;
+
+    if (CurrentLevel == CCAttrAmdSevSnp) {
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}
+
+/**
   Return whether MTRR is supported.
 
   @param[out]  FixedMtrrSupported   Return whether fixed MTRR is supported.
@@ -162,9 +200,9 @@ MtrrLibIsMtrrSupported (
   MSR_IA32_MTRRCAP_REGISTER  MtrrCap;
 
   //
-  // MTRR is not supported in TD-Guest.
+  // MTRR is not supported in TD-Guest or SEV-SNP guests
   //
-  if (TdIsEnabled ()) {
+  if (TdIsEnabled () || SnpIsEnabled ()) {
     return FALSE;
   }
 

--- a/UefiCpuPkg/Library/MtrrLib/MtrrLib.inf
+++ b/UefiCpuPkg/Library/MtrrLib/MtrrLib.inf
@@ -37,4 +37,5 @@
 
 [Pcd]
   gUefiCpuPkgTokenSpaceGuid.PcdCpuNumberOfReservedVariableMtrrs   ## SOMETIMES_CONSUMES
+  gEfiMdePkgTokenSpaceGuid.PcdConfidentialComputingGuestAttr      ## SOMETIMES_CONSUMES
 


### PR DESCRIPTION
# Avoid MTRR usage under SEV-SNP

During boot OVMF verifies that the MTRRs - which don't exist under SEV-SNP - are in their reset state. QEMU is 'emulating' the MTRRs by returning the last value written. During an SVSM reboot of the VMPL 2 OVMF guest, the verification fails. But since MTRRs don't exist, OVMF shouldn't even try. These changes have MtrrLibIsMtrrSupported() return false if running under SEV-SNP. To do that, the PCD that reports SEV-SNP needs to be set up a bit earlier than it was.